### PR TITLE
Fix/api dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -49,12 +49,15 @@ FROM base AS runner
 WORKDIR /app
 
 # Don't run production as root
+RUN apt update -y && apt install -y openssl libssl-dev curl
 RUN groupadd -r expressjs && useradd -r -g expressjs expressjs \
     && mkdir -p /home/expressjs/Downloads \
     && chown -R expressjs:expressjs /home/expressjs
 
+COPY --from=installer /app .
+RUN chown -R expressjs:expressjs /app
+
 USER expressjs
 
-COPY --from=installer /app .
 
 CMD node --max-old-space-size=12000 apps/api/dist/src/index.js

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -54,8 +54,7 @@ RUN groupadd -r expressjs && useradd -r -g expressjs expressjs \
     && mkdir -p /home/expressjs/Downloads \
     && chown -R expressjs:expressjs /home/expressjs
 
-COPY --from=installer /app .
-RUN chown -R expressjs:expressjs /app
+COPY --from=installer --chown=expressjs:expressjs /app .
 
 USER expressjs
 

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -4,6 +4,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["tracing", "interactiveTransactions"]
+  binaryTargets = ["debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
# Description

This Pull Request addresses two issues encountered during the `API image building` process:

1. **Prisma Client OpenSSL Error**: Fixes an error related to OpenSSL that occurs when initializing the Prisma Client during the Docker image build. This ensures that the necessary OpenSSL dependencies are properly installed and configured.

2. **Permission Error Accessing `node_modules` with `expressjs` User**: Resolves a permission error that arises when the `expressjs` user attempts to access the `node_modules` directory. The fix adjusts file permissions and ownership so that the `expressjs` user has the appropriate access rights.

# Changes

- Updated the `apps/api/Dockerfile` to include the installation of OpenSSL dependencies required by Prisma Client.
- Updated the `prisma.schema` file to add the openssl binary target.
- Modified file permissions for the `node_modules` directory to be accessible by the `expressjs` user.

# Testing

- Built the Docker image locally to ensure that the OpenSSL error is resolved.
- Verified that the `expressjs` user can access `node_modules` without permission issues by running the container and checking the application logs.
