### PR TITLE
update: SubscriptionBadge open-source settings

### DIFF
--- a/apps/web/src/components/SubscriptionBadge.tsx
+++ b/apps/web/src/components/SubscriptionBadge.tsx
@@ -296,7 +296,7 @@ const plans: Record<PlanName, Plan> = {
     editorSeats: 'Unlimited (free)',
     viewerSeats: 'Unlimited viewer seats (free)',
     schedules: 'Unlimited scheduled runs',
-    snapshots: true,
+    snapshots: false,
     pdfExport: false,
     slackIntegration: false,
     granularPermissions: false,


### PR DESCRIPTION
### Description:
SubscriptionBadge had an inconsistency for open-source version that currently doesn't support Snapshots.

### Changes Made:
Updated the SubscriptionBadge open-source settings: snapshots to false