### PR TITLE
Add PNG export for Notebook's visualization blocks

### DIFF
--- a/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
@@ -133,7 +133,7 @@ export function PythonOutput(props: ItemProps) {
               />
               {!props.isDashboardView && (
                 <button
-                  className="max-w-10 relative bottom-[2px] bg-white rounded-md border border-gray-200 p-1 hover:bg-gray-50 z-10 text-xs text-gray-400"
+                  className="relative bottom-[1px] right-[1px] bg-white rounded-tl-md rounded-br-md border border-gray-200 p-1 hover:bg-gray-50 z-10 text-xs text-gray-400"
                   onClick={onExportToPNG}
                 >
                   PNG

--- a/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
@@ -25,6 +25,7 @@ interface Props {
   isPDF: boolean
   isDashboardView: boolean
   lazyRender: boolean
+  blockId: string
 }
 
 let domPurify: DOMPurifyI
@@ -81,6 +82,7 @@ export function PythonOutputs(props: Props) {
           key={i}
           className={clsx(
             ['plotly'].includes(output.type) ? 'flex-grow' : '',
+            !props.isDashboardView ? 'flex flex-col items-end' : '',
             'bg-white overflow-x-scroll'
           )}
         >
@@ -91,6 +93,7 @@ export function PythonOutputs(props: Props) {
             isPDF={props.isPDF}
             canFixWithAI={props.canFixWithAI}
             isDashboardView={props.isDashboardView}
+            blockId={props.blockId}
           />
         </div>
       ))}
@@ -105,6 +108,7 @@ interface ItemProps {
   isPDF: boolean
   isDashboardView: boolean
   canFixWithAI: boolean
+  blockId: string
 }
 export function PythonOutput(props: ItemProps) {
   const onExportToPNG = () => {
@@ -112,7 +116,7 @@ export function PythonOutput(props: ItemProps) {
 
     downloadFile(
       `data:image/${props.output.format};base64, ${props.output.data}`,
-      'Generated Python image'
+      props.blockId
     )
   }
 
@@ -127,12 +131,14 @@ export function PythonOutput(props: ItemProps) {
                 alt="generated image"
                 src={`data:image/${props.output.format};base64, ${props.output.data}`}
               />
-              <button
-                className="absolute bottom-0 bg-white rounded-md border border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs text-gray-400"
-                onClick={onExportToPNG}
-              >
-                PNG
-              </button>
+              {!props.isDashboardView && (
+                <button
+                  className="max-w-10 relative bottom-[2px] bg-white rounded-md border border-gray-200 p-1 hover:bg-gray-50 z-10 text-xs text-gray-400"
+                  onClick={onExportToPNG}
+                >
+                  PNG
+                </button>
+              )}
             </>
           )
       }

--- a/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
@@ -12,6 +12,7 @@ import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/20/solid'
 import createDomPurify, { DOMPurifyI } from 'dompurify'
 import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import useResettableState from '@/hooks/useResettableState'
+import { downloadFile } from '@/utils/file'
 import debounce from 'lodash.debounce'
 import { PythonBlock } from '@briefer/editor'
 
@@ -106,16 +107,33 @@ interface ItemProps {
   canFixWithAI: boolean
 }
 export function PythonOutput(props: ItemProps) {
+  const onExportToPNG = () => {
+    if (props.output.type !== 'image' || props.output.format !== 'png') return
+
+    downloadFile(
+      `data:image/${props.output.format};base64, ${props.output.data}`,
+      'Generated Python image'
+    )
+  }
+
   switch (props.output.type) {
     case 'image':
       switch (props.output.format) {
         case 'png':
           return (
-            <img
-              className="printable-block"
-              alt="generated image"
-              src={`data:image/${props.output.format};base64, ${props.output.data}`}
-            />
+            <>
+              <img
+                className="printable-block"
+                alt="generated image"
+                src={`data:image/${props.output.format};base64, ${props.output.data}`}
+              />
+              <button
+                className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs"
+                onClick={onExportToPNG}
+              >
+                PNG
+              </button>
+            </>
           )
       }
     case 'stdio':

--- a/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
@@ -128,7 +128,7 @@ export function PythonOutput(props: ItemProps) {
                 src={`data:image/${props.output.format};base64, ${props.output.data}`}
               />
               <button
-                className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs"
+                className="absolute bottom-0 bg-white rounded-md border border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs text-gray-400"
                 onClick={onExportToPNG}
               >
                 PNG

--- a/apps/web/src/components/v2Editor/customBlocks/python/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/python/index.tsx
@@ -277,6 +277,7 @@ function PythonBlock(props: Props) {
         isDashboardView={props.dashboardPlace === 'view'}
         lazyRender={props.dashboardPlace === 'controls'}
         canFixWithAI={hasOaiKey}
+        blockId={blockId}
       />
     )
   }
@@ -463,6 +464,7 @@ function PythonBlock(props: Props) {
               isPDF={props.isPDF}
               isDashboardView={false}
               lazyRender={!props.isPDF}
+              blockId={blockId}
             />
           </ScrollBar>
         </div>

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
@@ -154,7 +154,7 @@ function VisualizationView(props: Props) {
           )}
         </button>
       )}
-      {props.isHidden && !props.isDashboard && (
+      {!props.isDashboard && (
         <button
           className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs text-gray-400"
           onClick={props.onExportToPNG}

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
@@ -154,14 +154,16 @@ function VisualizationView(props: Props) {
           )}
         </button>
       )}
-      {!props.isDashboard && (
-        <button
-          className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs text-gray-400"
-          onClick={props.onExportToPNG}
-        >
-          PNG
-        </button>
-      )}
+      {!props.isDashboard &&
+        props.chartType !== 'number' &&
+        props.chartType !== 'trend' && (
+          <button
+            className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs text-gray-400"
+            onClick={props.onExportToPNG}
+          >
+            PNG
+          </button>
+        )}
     </div>
   )
 }

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
@@ -156,7 +156,7 @@ function VisualizationView(props: Props) {
       )}
       {props.isHidden && !props.isDashboard && (
         <button
-          className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs"
+          className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs text-gray-400"
           onClick={props.onExportToPNG}
         >
           PNG

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/VisualizationView.tsx
@@ -39,6 +39,7 @@ interface Props {
   renderer?: 'canvas' | 'svg'
   isHidden: boolean
   onToggleHidden: () => void
+  onExportToPNG?: () => void
   isDashboard: boolean
   isEditable: boolean
 }
@@ -151,6 +152,14 @@ function VisualizationView(props: Props) {
           ) : (
             <ChevronDoubleLeftIcon className="h-3 w-3 text-gray-400" />
           )}
+        </button>
+      )}
+      {props.isHidden && !props.isDashboard && (
+        <button
+          className="absolute bottom-0 bg-white rounded-tl-md rounded-br-md border-t border-l border-gray-200 p-1 hover:bg-gray-50 z-10 right-0 text-xs"
+          onClick={props.onExportToPNG}
+        >
+          PNG
         </button>
       )}
     </div>

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
@@ -202,6 +202,36 @@ function VisualizationBlock(props: Props) {
     props.block.setAttribute('controlsHidden', !controlsHidden)
   }, [controlsHidden, props.block])
 
+  const onExportToPNG = () => {
+    // we don't need to check if props.renderer is undefined because the application sets as 'canvas' in this case
+    // TODO: add download for svg visualizations
+    if (props.renderer === 'svg') return
+
+    const canvas = document.querySelector(
+      `div[data-block-id=${blockId}] canvas`
+    ) as HTMLCanvasElement
+
+    // TODO: identify when this is true
+    if (!canvas) return
+
+    const imageUrl = canvas.toDataURL('image/png')
+    var downloadLink = document.createElement('a')
+
+    // some browsers don't support this solution
+    if (typeof downloadLink.download === 'undefined') {
+      // TODO: verify a solution for downloading in unsupported browsers
+      // 'window.location.href = downloadLink' no long works due to new Chrome policies
+      return
+    }
+
+    downloadLink.download = title || 'Visualization'
+    downloadLink.href = imageUrl
+
+    document.body.appendChild(downloadLink)
+    downloadLink.click()
+    document.body.removeChild(downloadLink)
+  }
+
   const onChangeChartType = useCallback(
     (chartType: ChartType) => {
       props.block.setAttribute('chartType', chartType)
@@ -426,6 +456,7 @@ function VisualizationBlock(props: Props) {
         renderer={props.renderer}
         isHidden={controlsHidden}
         onToggleHidden={onToggleHidden}
+        onExportToPNG={onExportToPNG}
         isDashboard={props.isDashboard}
         isEditable={isEditable}
       />
@@ -555,6 +586,7 @@ function VisualizationBlock(props: Props) {
             renderer={props.renderer}
             isHidden={controlsHidden}
             onToggleHidden={onToggleHidden}
+            onExportToPNG={onExportToPNG}
             isDashboard={props.isDashboard}
             isEditable={isEditable}
           />

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
@@ -203,10 +203,16 @@ function VisualizationBlock(props: Props) {
     props.block.setAttribute('controlsHidden', !controlsHidden)
   }, [controlsHidden, props.block])
 
-  const onExportToPNG = () => {
+  const onExportToPNG = async () => {
     // we don't need to check if props.renderer is undefined because the application sets as 'canvas' in this case
-    // TODO: add download for svg visualizations
     if (props.renderer === 'svg') return
+
+    // if the controls are visible the canvas got shrinked, making the export smaller
+    if (!controlsHidden) {
+      onToggleHidden()
+      // tick to ensure the canvas size gets updated
+      await new Promise((r) => setTimeout(r, 0))
+    }
 
     const canvas = document.querySelector(
       `div[data-block-id=${blockId}] canvas`
@@ -214,8 +220,6 @@ function VisualizationBlock(props: Props) {
 
     // TODO: identify when this is true
     if (!canvas) return
-
-    if (!controlsHidden) onToggleHidden()
 
     const imageUrl = canvas.toDataURL('image/png')
     const fileName = title || 'Visualization'

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
@@ -38,6 +38,7 @@ import { VisualizationExecTooltip } from '../../ExecTooltip'
 import useFullScreenDocument from '@/hooks/useFullScreenDocument'
 import HiddenInPublishedButton from '../../HiddenInPublishedButton'
 import useEditorAwareness from '@/hooks/useEditorAwareness'
+import { downloadFile } from '@/utils/file'
 
 function didChangeFilters(
   oldFilters: VisualizationFilter[],
@@ -215,21 +216,8 @@ function VisualizationBlock(props: Props) {
     if (!canvas) return
 
     const imageUrl = canvas.toDataURL('image/png')
-    const downloadLink = document.createElement('a')
-
-    // some browsers don't support this solution
-    if (typeof downloadLink.download === 'undefined') {
-      // TODO: verify a solution for downloading in unsupported browsers
-      // 'window.location.href = downloadLink' no long works due to new Chrome policies
-      return
-    }
-
-    downloadLink.download = title || 'Visualization'
-    downloadLink.href = imageUrl
-
-    document.body.appendChild(downloadLink)
-    downloadLink.click()
-    document.body.removeChild(downloadLink)
+    const fileName = title || 'Visualization'
+    downloadFile(imageUrl, fileName)
   }
 
   const onChangeChartType = useCallback(

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
@@ -215,7 +215,7 @@ function VisualizationBlock(props: Props) {
     if (!canvas) return
 
     const imageUrl = canvas.toDataURL('image/png')
-    var downloadLink = document.createElement('a')
+    const downloadLink = document.createElement('a')
 
     // some browsers don't support this solution
     if (typeof downloadLink.download === 'undefined') {

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
@@ -212,7 +212,7 @@ function VisualizationBlock(props: Props) {
     )
       return
 
-    // if the controls are visible the canvas got shrinked, making the export smaller
+    // if the controls are visible the canvas shrinks, making the export smaller
     if (!controlsHidden) {
       onToggleHidden()
       // tick to ensure the canvas size gets updated

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
@@ -205,7 +205,12 @@ function VisualizationBlock(props: Props) {
 
   const onExportToPNG = async () => {
     // we don't need to check if props.renderer is undefined because the application sets as 'canvas' in this case
-    if (props.renderer === 'svg') return
+    if (
+      props.renderer === 'svg' ||
+      chartType === 'number' ||
+      chartType === 'trend'
+    )
+      return
 
     // if the controls are visible the canvas got shrinked, making the export smaller
     if (!controlsHidden) {
@@ -215,7 +220,7 @@ function VisualizationBlock(props: Props) {
     }
 
     const canvas = document.querySelector(
-      `div[data-block-id=${blockId}] canvas`
+      `div[data-block-id='${blockId}'] canvas`
     ) as HTMLCanvasElement
 
     // TODO: identify when this is true

--- a/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/visualization/index.tsx
@@ -215,6 +215,8 @@ function VisualizationBlock(props: Props) {
     // TODO: identify when this is true
     if (!canvas) return
 
+    if (!controlsHidden) onToggleHidden()
+
     const imageUrl = canvas.toDataURL('image/png')
     const fileName = title || 'Visualization'
     downloadFile(imageUrl, fileName)

--- a/apps/web/src/utils/file.ts
+++ b/apps/web/src/utils/file.ts
@@ -19,3 +19,20 @@ export function readFile(
     }
   })
 }
+
+export function downloadFile(url: string, name: string) {
+  const downloadLink = document.createElement('a')
+
+  // some browsers don't support the a[download] solution
+  if (typeof downloadLink.download === 'undefined') {
+    // 'window.location.href = downloadLink' no long works due to some Chrome policies update
+    return
+  }
+
+  downloadLink.download = name
+  downloadLink.href = url
+
+  document.body.appendChild(downloadLink)
+  downloadLink.click()
+  document.body.removeChild(downloadLink)
+}

--- a/apps/web/src/utils/file.ts
+++ b/apps/web/src/utils/file.ts
@@ -23,12 +23,6 @@ export function readFile(
 export function downloadFile(url: string, name: string) {
   const downloadLink = document.createElement('a')
 
-  // some browsers don't support the a[download] solution
-  if (typeof downloadLink.download === 'undefined') {
-    // 'window.location.href = downloadLink' no long works due to some Chrome policies update
-    return
-  }
-
   downloadLink.download = name
   downloadLink.href = url
 


### PR DESCRIPTION
Adds #18

Currently, exporting works for all Briefer's visualization blocks and Python's graph outputs in the Notebook tab.

### TODO
- [x] Show button when Visualization Controls are not hidden
- [x] Show button in Python's graph outputs
- [x] ~~Identify when the `renderer` is `svg` and code a solution for downloading it~~
  - The only case where the `renderer` is `svg` is in the Dashboard's block list, where the export button is not visible
- [x] Hide button if chart doesn't support export
- [x] ~~Support Internet Explorer and Opera Mini~~
  - [Can I Use `a[download]`](https://caniuse.com/?search=a.download)
  - Briefer itself doesn't support Internet Explorer, so we don't need to do this
- [x] Simplify the export function (maybe by downloading a library or moving the code to a helper file)