### PR TITLE
fix missing migration on docker compose dev

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -16,6 +16,19 @@ services:
     volumes:
       - postgres_dev_data:/var/lib/postgresql/data
 
+  db_migration:
+    build:
+      context: '.'
+      dockerfile: 'apps/api/Dockerfile'
+    working_dir: '/app/packages/database'
+    command: ['npx', 'prisma', 'migrate', 'deploy']
+    environment:
+      NODE_ENV: 'development'
+      POSTGRES_PRISMA_URL: 'postgresql://postgres:password@postgres:5432/briefer?schema=public'
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   jupyter_server:
     container_name: briefer_jupyter_server_dev
     labels:


### PR DESCRIPTION
The docker compose dev was missing a migration. Therefore the API wasn't able to initialize.