### PR TITLE
fix generating incorrect port when running on dev mode

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -5,7 +5,7 @@ set -e
 if [ ! -f ./apps/api/.env ]; then
   echo "NODE_ENV=development" > ./apps/api/.env
   echo "LOG_LEVEL=debug" >> ./apps/api/.env
-  echo "API_URL='https://localhost:3000'" >> ./apps/api/.env
+  echo "API_URL='https://localhost:8080'" >> ./apps/api/.env
   echo "FRONTEND_URL='https://localhost:3000'" >> ./apps/api/.env
   echo "TLD=localhost" >> ./apps/api/.env
   echo "LOGIN_JWT_SECRET=$(openssl rand -hex 24)" >> ./apps/api/.env


### PR DESCRIPTION
The `start-dev.sh` script was using the frontend URL as the API URL. As a consequence, the frontend was redirecting the user to a route that did not exist in the frontend itself during authentication.