### PR TITLE
fix serialization issue with date dtypes of df

### DIFF
--- a/apps/api/src/python/query/index.ts
+++ b/apps/api/src/python/query/index.ts
@@ -421,11 +421,6 @@ def _briefer_list_dataframes():
                             col["categories"] = categories
                         except:
                             pass
-                    # Handle datetime and date types by converting them to strings
-                    elif pd.api.types.is_datetime64_any_dtype(dtype):
-                        df[col["name"]] = df[col["name"]].apply(
-                            lambda x: x.isoformat() if isinstance(x, (datetime, date)) else x
-                        )  # Only apply isoformat to datetime objects
 
                 dataframes.append({"name": name, "columns": columns})
         except Exception as e:

--- a/apps/api/src/python/query/index.ts
+++ b/apps/api/src/python/query/index.ts
@@ -389,14 +389,6 @@ export async function listDataFrames(
 def _briefer_list_dataframes():
     import pandas as pd
     import json
-    from datetime import date, datetime
-
-    def handle_non_serializable(obj):
-        """Custom handler for non-serializable objects."""
-        if isinstance(obj, (datetime, date)):
-            return obj.isoformat()  # Convert datetime/date to ISO format string
-        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
-
     dataframes = []
 
     names = %who_ls

--- a/apps/api/src/python/query/index.ts
+++ b/apps/api/src/python/query/index.ts
@@ -426,10 +426,7 @@ def _briefer_list_dataframes():
         except Exception as e:
             pass
 
-    try:
-        print(json.dumps(dataframes, default=handle_non_serializable))
-    except Exception as e:
-        print(f"Error serializing dataframes: {e}")
+    print(json.dumps(dataframes, default=str))
 
 _briefer_list_dataframes()
 del _briefer_list_dataframes`

--- a/apps/api/src/python/query/index.ts
+++ b/apps/api/src/python/query/index.ts
@@ -429,7 +429,6 @@ def _briefer_list_dataframes():
 
                 dataframes.append({"name": name, "columns": columns})
         except Exception as e:
-            print(f"Error processing dataframe '{name}': {e}")
             pass
 
     try:


### PR DESCRIPTION
Issue Fix: #15

This issue arises because JSON can't serialize DATE types by default. To fix this, we need to handle it in a custom way by converting DATE and DATETIME objects to isoformat() before serialization.

The root cause of the issue is that whenever we have a DataFrame (df), it tries to store the data in a format suitable for visualization. When storing it in JSON format, serialization is required.

The vis.to_json function itself works perfectly fine.

Let me know if you'd like any further adjustments!