### PR TITLE
Prefer "RegExp.exec" over "String.match"

### DIFF
--- a/apps/web/src/hooks/useQueryArgs.ts
+++ b/apps/web/src/hooks/useQueryArgs.ts
@@ -12,7 +12,7 @@ function extractParamValue(
 
   const regex = new RegExp(regexPattern)
 
-  const match = path.match(regex)
+  const match = regex.exec(path)
 
   return match?.[1] ?? ''
 }


### PR DESCRIPTION
https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJNLUtwWXBqNUU5akRrTHVPRW41emsiLCJjb2RlIjoiJ2ZvbycubWF0Y2goL2Jhci8pOyIsImRlcGVuZGVuY2llcyI6W10sIm5hbWUiOiInZm9vJy5tYXRjaCgvYmFyLyk7In0seyJpZCI6IkFSUDNBVkVfQ0ZPd05tazNDeXZoXyIsImNvZGUiOiIvYmFyLy5leGVjKCdmb28nKTsiLCJkZXBlbmRlbmNpZXMiOltdLCJuYW1lIjoiL2Jhci8uZXhlYygnZm9vJyk7In1dLCJjb25maWciOnsibmFtZSI6IiIsInBhcmFsbGVsIjp0cnVlLCJkYXRhQ29kZSI6IiIsImdsb2JhbFRlc3RDb25maWciOnsiZGVwZW5kZW5jaWVzIjpbXX19fQ
![image](https://github.com/user-attachments/assets/006408ea-ebd8-4320-8c09-ea61bd841ca0)
