### PR TITLE
docs: Add note about sign-in issues in troubleshooting

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -165,3 +165,17 @@ Check if it complains about any missing environment variables or if there's any 
 If you can't figure out what's happening, please [open an issue here](https://github.com/briefercloud/briefer/issues).
 
 </details>
+
+<details>
+  <summary>I can access the web application, but sign-in is not working</summary>
+
+If you're running Briefer from another machine - for example an external server, Raspbery Pi etc - make sure you have enabled HTTPS for your current setup while accessing Briefer's application on port 3000.
+
+In case you can't enable HTTPS or just want to try it out, you can run Briefer in an insecure manner by setting the `ALLOW_HTTP` environment variable to `true`:
+
+```sh
+user@server:~$ ALLOW_HTTP=true briefer
+```
+
+This will not set the session cookie as Secure, thus allowing you to sign-in using HTTP. Note this option should not be used in production given the [security risks](https://owasp.org/www-community/vulnerabilities/Insecure_Transport).
+</details>


### PR DESCRIPTION
### Summary

This PR adds a note about the sign-in issue I had resolved a few days ago while trying to run Briefer from a remote server (Raspberry Pi). In that scenario, I was running the application using `http://` on port 3000 and while the connection was successful, sign-in was not working properly and the page just reloaded.

While troubleshooting, we have identified the issue was in how Briefer sends the session cookie as Secure but browsers prevent saving those cookies when running from an insecure protocol such as HTTP.