### PR TITLE
Preventing file chooser to opens twice

### DIFF
--- a/apps/web/src/components/forms/FileUploadInput.tsx
+++ b/apps/web/src/components/forms/FileUploadInput.tsx
@@ -81,6 +81,7 @@ export default function FileUploadInput<T extends FieldValues>(
             <div className="pt-4 flex items-center justify-center text-sm leading-6 text-gray-600">
               <label
                 htmlFor="file-upload"
+                onClick={(e) => e.preventDefault()}
                 className="relative cursor-pointer rounded-md font-semibold text-primary-600 focus-within:outline-none focus-within:ring-0 hover:text-primary-500"
               >
                 <span>{props.label}</span>


### PR DESCRIPTION
I added a prevent default to avoid the file chooser to opens twice when selecting a BigQuery service.

Issue: #61 