### PR TITLE
hide tooltip when something inside it is open

### DIFF
--- a/apps/web/src/components/v2Editor/customBlocks/richText/index.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/richText/index.tsx
@@ -186,7 +186,7 @@ const RichTextBlock = (props: Props) => {
       data-block-id={id}
     >
       <div className={editor?.isFocused ? 'block' : 'hidden'}>
-        {editor && <FormattingToolbar editor={editor} />}
+        <div>{editor && <FormattingToolbar editor={editor} />}</div>
       </div>
       <EditorContent editor={editor} />
     </div>


### PR DESCRIPTION
This changes how the positioning of [Tippy](https://kabbouchi.github.io/tippyjs-v4-docs/getting-started/) is calculated and fixes the bug of the tooltip still showing after clicking outside the text block.