### PR TITLE
Changed the horizontal scroll for the python output 

### DIFF
--- a/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
@@ -51,6 +51,7 @@ export function PythonOutputs(props: Props) {
   )
 
   useEffect(() => {
+    console.log('outputs', props.outputs)
     if (!props.lazyRender || rendered === props.outputs.length) {
       return
     }
@@ -82,7 +83,8 @@ export function PythonOutputs(props: Props) {
           key={i}
           className={clsx(
             ['plotly'].includes(output.type) ? 'flex-grow' : '',
-            'bg-white overflow-x-scroll'
+            !['stdio'].includes(output.type) ? 'overflow-x-scroll' : '',
+            'bg-white'
           )}
         >
           <PythonOutput


### PR DESCRIPTION
Removed the `overflow-x-scroll` if there's `stdio` in the list of python outputs. This change will make the whole block scrollable if there's a python stdio, which will include the graph too. So if there's python text output and a `plotly` graph, the graph will also be in the scrollable block. If this is not desirable, let me know and I'll try to find another method to fix this (maybe group text blocks with each other).


Closes #97 