### PR TITLE
Hide redundant horizontal scrollbars on Windows

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -320,7 +320,7 @@ export default function Layout({
       />
 
       {isSideBarOpen && (
-        <div className="flex flex-col h-full bg-ceramic-50/60 min-w-[33%] max-w-[33%] lg:min-w-[25%] lg:max-w-[25%] overflow-scroll border-r border-gray-200">
+        <div className="flex flex-col h-full bg-ceramic-50/60 min-w-[33%] max-w-[33%] lg:min-w-[25%] lg:max-w-[25%] overflow-auto border-r border-gray-200">
           <div className="flex items-center justify-between pt-4 px-5">
             <span className="font-trap tracking-tight font-semibold text-2xl antialiased text-gray-800">
               briefer

--- a/apps/web/src/components/schemaExplorer/TableDetails.tsx
+++ b/apps/web/src/components/schemaExplorer/TableDetails.tsx
@@ -16,7 +16,7 @@ export default function TableDetails(props: Props) {
       <div className="relative flex px-4 py-2 text-xs font-medium border-b bg-gray-50 text-gray-600 items-center justify-between font-mono group w-full gap-x-1.5">
         <Columns3Icon className="h-3 w-3 text-gray-500" />
         <div className="pr-2 flex-grow overflow-x-hidden">
-          <h4 className="overflow-x-scroll">{props.tableName}</h4>
+          <h4 className="overflow-x-auto">{props.tableName}</h4>
         </div>
         <button
           onMouseEnter={() => setHovering(true)}
@@ -40,7 +40,7 @@ export default function TableDetails(props: Props) {
               >
                 <div className="pr-2 flex-grow overflow-x-hidden">
                   {/* TODO we need to figure out all possible type names to select appropriate icons every time */}
-                  <h5 className="font-mono text-xs text-gray-600 overflow-x-scroll">
+                  <h5 className="font-mono text-xs text-gray-600 overflow-x-auto">
                     {column.name}
                   </h5>
                 </div>

--- a/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
+++ b/apps/web/src/components/v2Editor/customBlocks/python/PythonOutput.tsx
@@ -82,7 +82,7 @@ export function PythonOutputs(props: Props) {
           key={i}
           className={clsx(
             ['plotly'].includes(output.type) ? 'flex-grow' : '',
-            'bg-white overflow-x-scroll'
+            'bg-white overflow-x-auto'
           )}
         >
           <PythonOutput

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -138,7 +138,7 @@ body {
 .python-html-output th,
 .python-html-output td {
   max-width: 250px;
-  overflow: scroll;
+  overflow: auto;
   padding: 0.3rem 0.5rem;
   border: 1px solid theme(colors.gray.200);
   white-space: nowrap;


### PR DESCRIPTION
On Windows, a large portion of the Briefer UI currently displays unnecessary horizontal scrollbars even when content is not scrollable. This PR fixes the most obvious places - the sidebar, schema explorer and Python output.

Additionally, this article describes how developers can simulate this behavior on macOS as well (I hope the described mechanisms still work): https://kilianvalkhof.com/2021/css-html/you-want-overflow-auto-not-overflow-scroll/