### PR TITLE
SSL configs equal to prefer in sslmode

### DIFF
--- a/apps/api/src/config/base.ts
+++ b/apps/api/src/config/base.ts
@@ -25,7 +25,7 @@ export interface IBaseConfig {
   POSTGRES_CONNECTION_LIMIT: number
   POSTGRES_POOL_TIMEOUT: number
   POSTGRES_SSL_DISABLED: boolean
-  POSTGRES_SSL_REJECT_UNAUTHORIZED: boolean
+  POSTGRES_SSL_REJECT_UNAUTHORIZED: boolean | null
   POSTGRES_SSL_CA: string | null
   ENVIRONMENT_VARIABLES_ENCRYPTION_KEY: string
   DATASOURCES_ENCRYPTION_KEY: string
@@ -59,7 +59,7 @@ export class BaseConfig implements IBaseConfig {
   public readonly POSTGRES_CONNECTION_LIMIT: number
   public readonly POSTGRES_POOL_TIMEOUT: number
   public readonly POSTGRES_SSL_DISABLED: boolean
-  public readonly POSTGRES_SSL_REJECT_UNAUTHORIZED: boolean
+  public readonly POSTGRES_SSL_REJECT_UNAUTHORIZED: boolean | null
   public readonly POSTGRES_SSL_CA: string | null
   public readonly ENVIRONMENT_VARIABLES_ENCRYPTION_KEY: string
   public readonly DATASOURCES_ENCRYPTION_KEY: string
@@ -103,12 +103,11 @@ export class BaseConfig implements IBaseConfig {
       false
     )
 
-    this.POSTGRES_SSL_REJECT_UNAUTHORIZED = this.getBooleanVar(
-      'POSTGRES_SSL_REJECT_UNAUTHORIZED',
-      false
+    this.POSTGRES_SSL_REJECT_UNAUTHORIZED = this.getMaybeBooleanVar(
+      'POSTGRES_SSL_REJECT_UNAUTHORIZED'
     )
 
-    this.POSTGRES_SSL_CA = process.env['POSTGRES_SSL_CA'] || null
+    this.POSTGRES_SSL_CA = process.env['POSTGRES_SSL_CA']?.trim() || null
 
     this.ENVIRONMENT_VARIABLES_ENCRYPTION_KEY = getVar(
       'ENVIRONMENT_VARIABLES_ENCRYPTION_KEY'
@@ -157,7 +156,7 @@ export class BaseConfig implements IBaseConfig {
   }
 
   private getBooleanVar(name: string, or?: boolean): boolean {
-    const value = process.env[name]?.toLowerCase()
+    const value = process.env[name]?.toLowerCase().trim()
     if (value === undefined && or !== undefined) {
       return or
     }
@@ -167,5 +166,19 @@ export class BaseConfig implements IBaseConfig {
     }
 
     return false
+  }
+
+  private getMaybeBooleanVar(name: string): boolean | null {
+    const value = process.env[name]?.toLowerCase().trim()
+
+    if (value === 'true' || value === '1' || value === 'yes') {
+      return true
+    }
+
+    if (value === 'false' || value === '0' || value === 'no') {
+      return false
+    }
+
+    return null
   }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -46,18 +46,25 @@ const getDBUrl = async () => {
 }
 
 async function main() {
+  const cfg = config()
   const dbUrl = await getDBUrl()
 
-  const initOptions = {
+  const initOptions: db.InitOptions = {
     connectionString: dbUrl,
-    ssl: !config().POSTGRES_SSL_DISABLED
-      ? {
-          enabled: true,
-          ca: config().POSTGRES_SSL_CA ?? undefined,
-          rejectUnauthorized:
-            config().POSTGRES_SSL_REJECT_UNAUTHORIZED ?? undefined,
-        }
-      : { enabled: false as const },
+    ssl: false,
+  }
+  if (!cfg.POSTGRES_SSL_DISABLED) {
+    if (
+      cfg.POSTGRES_SSL_CA !== null ||
+      cfg.POSTGRES_SSL_REJECT_UNAUTHORIZED !== null
+    ) {
+      initOptions.ssl = {
+        rejectUnauthorized: cfg.POSTGRES_SSL_REJECT_UNAUTHORIZED ?? undefined,
+        ca: cfg.POSTGRES_SSL_CA ?? undefined,
+      }
+    } else {
+      initOptions.ssl = 'prefer'
+    }
   }
 
   db.init(initOptions)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -50,15 +50,16 @@ async function main() {
 
   const initOptions = {
     connectionString: dbUrl,
-    ssl:
-      config().NODE_ENV !== 'development' && !config().POSTGRES_SSL_DISABLED
-        ? {
-            enabled: true,
-            ca: config().POSTGRES_SSL_CA,
-            rejectUnauthorized: config().POSTGRES_SSL_REJECT_UNAUTHORIZED,
-          }
-        : { enabled: false as const },
+    ssl: !config().POSTGRES_SSL_DISABLED
+      ? {
+          enabled: true,
+          ca: config().POSTGRES_SSL_CA ?? undefined,
+          rejectUnauthorized:
+            config().POSTGRES_SSL_REJECT_UNAUTHORIZED ?? undefined,
+        }
+      : { enabled: false as const },
   }
+
   db.init(initOptions)
 
   const app = express()

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: briefer
 description: The helm chart for Briefer's open-source version.
 type: application
-version: 0.1.4
-appVersion: '0.1.4'
+version: 0.1.5
+appVersion: '0.1.5'

--- a/chart/templates/api-deployment.yaml
+++ b/chart/templates/api-deployment.yaml
@@ -48,6 +48,12 @@ spec:
               value: '{{ .Values.api.env.postgresPort }}'
             - name: POSTGRES_DATABASE
               value: '{{ .Values.api.env.postgresDatabase }}'
+            - name: POSTGRES_SSL_DISABLED
+              value: '{{ .Values.api.env.postgresSslDisabled | default "false" }}'
+            - name: POSTGRES_SSL_REJECT_UNAUTHORIZED
+              value: '{{ .Values.api.env.postgresSslRejectUnauthorized }}'
+            - name: POSTGRES_SSL_CA
+              value: '{{ .Values.api.env.postgresSslCa }}'
           resources:
             requests:
               cpu: 100m
@@ -117,6 +123,12 @@ spec:
               value: '{{ .Values.api.env.postgresConnectionLimit | default "30" }}'
             - name: POSTGRES_POOL_TIMEOUT
               value: '{{ .Values.api.env.postgresPoolTimeout | default "10" }}'
+            - name: POSTGRES_SSL_DISABLED
+              value: '{{ .Values.api.env.postgresSslDisabled | default "false" }}'
+            - name: POSTGRES_SSL_REJECT_UNAUTHORIZED
+              value: '{{ .Values.api.env.postgresSslRejectUnauthorized }}'
+            - name: POSTGRES_SSL_CA
+              value: '{{ .Values.api.env.postgresSslCa }}'
 
             - name: LOGIN_LINK_EXPIRATION
               value: '{{ .Values.api.env.loginLinkExpiration | default "24h" }}'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ ai:
   image:
     repository: docker.io
     name: briefercloud/briefer-ai
-    tag: v0.0.66
+    tag: v0.0.74
     pullPolicy: Always
 
   resources:
@@ -47,7 +47,7 @@ web:
   image:
     repository: docker.io
     name: briefercloud/briefer-web
-    tag: v0.0.66
+    tag: v0.0.74
     pullPolicy: Always
 
   # optional
@@ -81,7 +81,7 @@ api:
   image:
     repository: docker.io
     name: briefercloud/briefer-api
-    tag: v0.0.66
+    tag: v0.0.74
     pullPolicy: Always
 
   resources:
@@ -106,6 +106,9 @@ api:
     postgresDatabase: briefer
     aiApiUrl: http://ai:8080
     allowHttp: 'false'
+    postgresSslDisabled: false
+    postgresSslRejectUnauthorized: false
+    postgresSslCa: ''
 
   secrets:
     postgresUsername: postgres

--- a/docker/setup/api.py
+++ b/docker/setup/api.py
@@ -60,9 +60,6 @@ def run_api(cfg):
         if k not in env:
             env[k] = v
 
-    if env["POSTGRES_HOSTNAME"] == "localhost" and not env.get("POSTGRES_SSL_DISABLED"):
-        env["POSTGRES_SSL_DISABLED"] = "true"
-
     with open("/app/api/apps/api/package.json", "r") as f:
         pkgjson = json.load(f)
         env["VERSION"] = pkgjson["version"]

--- a/docs/deployment/troubleshooting.mdx
+++ b/docs/deployment/troubleshooting.mdx
@@ -138,6 +138,10 @@ Briefer accepts the following environment variables to configure the SSL connect
 - `POSTGRES_SSL_REJECT_UNAUTHORIZED` (optional): Set this to `true` to reject unauthorized (self-signed) SSL certificates.
 - `POSTGRES_SSL_CA`: (optional): The path to the CA certificate file to validate the server certificate.
 
+<Note>
+If you're deploying Briefer using our Helm chart, you can set these values in the `values.yaml` file as `api.env.postgresSslDisabled`, `api.env.postgresSslRejectUnauthorized`, and `api.env.postgresSslCa`, respectively.
+</Note>
+
 If you're having issues with your Postgres SSL settings, make sure that you've set these environment variables correctly.
 
 By default, Briefer's connection will have the same SSL settings as using `sslmode=prefer` in a Postgres connection string.

--- a/docs/deployment/troubleshooting.mdx
+++ b/docs/deployment/troubleshooting.mdx
@@ -129,3 +129,17 @@ docker volume rm briefer_briefer_data
 ```
 
 </Accordion>
+
+<Accordion title="I'm having issues with my Postgres SSL settings">
+
+Briefer accepts the following environment variables to configure the SSL connection to your Postgres instance:
+
+- `POSTGRES_SSL_DISABLED`: Set this to `true` to disable SSL.
+- `POSTGRES_SSL_REJECT_UNAUTHORIZED` (optional): Set this to `true` to reject unauthorized (self-signed) SSL certificates.
+- `POSTGRES_SSL_CA`: (optional): The path to the CA certificate file to validate the server certificate.
+
+If you're having issues with your Postgres SSL settings, make sure that you've set these environment variables correctly.
+
+By default, Briefer's connection will have the same SSL settings as using `sslmode=prefer` in a Postgres connection string.
+
+</Accordion>

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -35,8 +35,8 @@ type InitOptions = {
   ssl:
     | {
         enabled: true
-        rejectUnauthorized: boolean
-        ca: string | null
+        rejectUnauthorized: boolean | undefined
+        ca: string | null | undefined
       }
     | {
         enabled: false


### PR DESCRIPTION
> A quick look at the pg-connection-string tests seems to suggest that `sslmode: prefer` is parsed the same as `ssl = true`;
> https://github.com/sequelize/sequelize/discussions/16287#discussioncomment-6480038