### PR TITLE
docs: update anchor links in GCP deployment table of contents

### DIFF
--- a/docs/deployment/gcp.mdx
+++ b/docs/deployment/gcp.mdx
@@ -20,7 +20,6 @@ This guide describes how to set up Briefer on a Google Cloud Platform (GCP) inst
 3. [Installing Docker](#3-installing-docker)
 4. [Running Briefer](#4-running-briefer)
 5. [(Optional) Configuring Nginx for Public Access](#optional-5-configuring-nginx-for-public-access)
-6. [Conclusion](#conclusion)
 
 ## 1. Prerequisites
 

--- a/docs/deployment/gcp.mdx
+++ b/docs/deployment/gcp.mdx
@@ -15,11 +15,11 @@ This guide describes how to set up Briefer on a Google Cloud Platform (GCP) inst
 
 ## Table of Contents
 
-1. [Prerequisites](#prerequisites)
-2. [Creating the Compute Engine Instance](#creating-the-compute-engine-instance)
-3. [Installing Docker](#installing-docker)
-4. [Running Briefer](#running-briefer)
-5. [(Optional) Configuring Nginx for Public Access](#optional-configuring-nginx-for-public-access)
+1. [Prerequisites](#1-prerequisites)
+2. [Creating the Compute Engine Instance](#2-creating-the-compute-engine-instance)
+3. [Installing Docker](#3-installing-docker)
+4. [Running Briefer](#4-running-briefer)
+5. [(Optional) Configuring Nginx for Public Access](#optional-5-configuring-nginx-for-public-access)
 6. [Conclusion](#conclusion)
 
 ## 1. Prerequisites


### PR DESCRIPTION
Fix GCP deployment documentation table of contents, that was pointing to invalid anchor links.