### PR TITLE
docs: fix markdown heading link and dev mode image

### DIFF
--- a/.github/contributing/CONTRIBUTING.md
+++ b/.github/contributing/CONTRIBUTING.md
@@ -6,7 +6,7 @@ In this document, you'll learn how to run Briefer in development mode and how to
 
 ### Contents
 
-- [Running Briefer in dev mode](#computer-running-briefer-in-dev-mode)
+- [Running Briefer in dev mode](#computer-running-briefer-in-development-mode)
 - [Questions, bugs, and feature requests](#bulb-questions-bugs-and-feature-requests)
 - [Submitting pull requests](#repeat-submitting-pull-requests)
 - [Troubleshooting](#wrench-troubleshooting)
@@ -19,13 +19,13 @@ In this document, you'll learn how to run Briefer in development mode and how to
 
 You need to be able to run Briefer in development mode to contribute to the project and test changes.
 
-<p>
-<picture align="center">
-  <source  align="center" media="(prefers-color-scheme: dark)" srcset="../assets/img/briefer-dev-mode-dark.png">
-  <source align="center" media="(prefers-color-scheme: light)" srcset="../assets/img/briefer-dev-mode.png">
-  <img align="center" alt="Briefer architecture diagram for dev mode" src="../assets/img/briefer-dev-mode.png">
-</picture>
-</p>
+<div align="center">
+  <picture>
+    <source  align="center" media="(prefers-color-scheme: dark)" srcset="../../assets/img/briefer-dev-mode-dark.png">
+    <source align="center" media="(prefers-color-scheme: light)" srcset="../../assets/img/briefer-dev-mode.png">
+    <img align="center" alt="Briefer architecture diagram for dev mode" src="../../assets/img/briefer-dev-mode.png">
+  </picture>
+</div>
 
 > [!NOTE]
 > If you're looking to deploy Briefer, you can check our [deployment guide here](./DEPLOYMENT.md). This guide is focused on running Briefer in _development_ mode.


### PR DESCRIPTION
This PR aims to improve documentation by fixing head links and fixing dev mode image path.

Before:

<img width="973" alt="image" src="https://github.com/user-attachments/assets/267c8aaf-5cb0-457b-965f-fcb1088d9234" />

After:

<img width="1223" alt="image" src="https://github.com/user-attachments/assets/14ad5e23-f39d-4251-bc97-4d415d43fc33" />