### PR TITLE
fix: Access env var

### DIFF
--- a/docker/setup/api.py
+++ b/docker/setup/api.py
@@ -45,7 +45,7 @@ def run_api(cfg):
       "PYTHON_ALLOWED_LIBRARIES": "plotly,matplotlib,numpy,pandas",
       "POSTGRES_USERNAME": cfg["POSTGRES_USERNAME"],
       "POSTGRES_PASSWORD": cfg["POSTGRES_PASSWORD"],
-      "POSTGRES_HOSTNAME": "localhost",
+      "POSTGRES_HOSTNAME": cfg.get("POSTGRES_HOSTNAME", "localhost"),
       "POSTGRES_PORT": "5432",
       "POSTGRES_DATABASE": "briefer",
       "ENVIRONMENT_VARIABLES_ENCRYPTION_KEY": cfg["ENVIRONMENT_VARIABLES_ENCRYPTION_KEY"],


### PR DESCRIPTION
While self-hosting Briefer, we encountered an issue where it couldn't find the RDS database we were connecting to. It turned out that the problem was due to Briefer always trying to access a local Postgres instance instead of using the POSTGRES_HOSTNAME provided as an environment variable. Happy to adjust the code in case you want to fix it using a different approach!